### PR TITLE
TrainOperationService updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Insert a ModuleScript as the child of the ServerScript and **then paste trainopservice.luau's contents inside of it**.
 - Name the module script "TrainOperationService" (necessary or doesn't work)
 ### Quick Setup
+NOTE: Quick setup may be outdated and will likely only be updated when there is a critical bug fix or a major update
 You can also use the Quick Setup.
 - Copy "quicksetup.luau" to your clipboard.
 - Paste it into the command bar in Studio (https://create.roblox.com/docs/studio/ui-overview#command-bar)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 - Name the script "Main" or any other name, and **then paste main.luau's contents inside of it**.
 - Insert a ModuleScript as the child of the ServerScript and **then paste trainopservice.luau's contents inside of it**.
 - Name the module script "TrainOperationService" (necessary or doesn't work)
+### Quick Setup
+You can also use the Quick Setup.
+- Copy "quicksetup.luau" to your clipboard.
+- Paste it into the command bar in Studio (https://create.roblox.com/docs/studio/ui-overview#command-bar)
+- Press enter, and check ServerScriptService for "Main"
 ### Requirements
 - Train MUST BE a Model
 - Train MUST HAVE tag "Train"
@@ -17,4 +22,4 @@
 ### Optional
 none yet
 ### If you find any errors,
-Announce me as soon as possible so I can deal with them.
+Announce Petrulici as soon as possible so I can deal with them.

--- a/main.luau
+++ b/main.luau
@@ -1,13 +1,26 @@
+local CollectionService = game:GetService("CollectionService")
+
 local TrainOperationService = require(script:FindFirstChild("TrainOperationService"))
 local trains = workspace:GetDescendants()
 
-for _, train : Instance in ipairs(trains) do
-	if train:IsA("Model") and train:HasTag("Train") then
+local TAG = "Train"
+
+for _, train : Instance in CollectionService:GetTagged(TAG) do
+	if train:IsA("Model") then
 		local seat = train:FindFirstChildOfClass("VehicleSeat")
 		if not seat then 
 			return 
 		end
-		seat:GetPropertyChangedSignal("Throttle"):Connect(TrainOperationService.StartOperations)
+		local throttleConnection = seat:GetPropertyChangedSignal("Throttle"):Connect(TrainOperationService.StartOperations)
+		local acConnection
+		acConnection = seat.AncestryChanged:Connect(function()
+			if seat:IsDescendantOf(workspace) == false then
+				throttleConnection:Disconnect()
+				acConnection:Disconnect()
+			end
+		end
+	else
+		warn(`[TrainService.Main] Non model given train tag: {train:GetFullName()}`)
 	end
 end
 TrainOperationService.StartOperations()

--- a/main.luau
+++ b/main.luau
@@ -18,7 +18,7 @@ for _, train : Instance in CollectionService:GetTagged(TAG) do
 				throttleConnection:Disconnect()
 				acConnection:Disconnect()
 			end
-		end
+		end)
 	else
 		warn(`[TrainService.Main] Non model given train tag: {train:GetFullName()}`)
 	end

--- a/quicksetup.luau
+++ b/quicksetup.luau
@@ -1,0 +1,109 @@
+-- run this inside the command bar to setup the train service
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local Main = Instance.new("Script")
+Main.Name = "Main"
+Main.Source = [[
+local CollectionService = game:GetService("CollectionService")
+
+local TrainOperationService = require(script:FindFirstChild("TrainOperationService"))
+local trains = workspace:GetDescendants()
+
+local TAG = "Train"
+
+for _, train : Instance in CollectionService:GetTagged(TAG) do
+	if train:IsA("Model") then
+		local seat = train:FindFirstChildOfClass("VehicleSeat")
+		if not seat then 
+			return 
+		end
+		local throttleConnection = seat:GetPropertyChangedSignal("Throttle"):Connect(TrainOperationService.StartOperations)
+		local acConnection
+		acConnection = seat.AncestryChanged:Connect(function()
+			if seat:IsDescendantOf(workspace) == false then
+				throttleConnection:Disconnect()
+				acConnection:Disconnect()
+			end
+		end
+	else
+		warn(`[TrainService.Main] Non model given train tag: {train:GetFullName()}`)
+	end
+end
+TrainOperationService.StartOperations()
+]]
+Main.Parent = ServerScriptService
+
+local Module = Instance.new("ModuleScript")
+Module.Name = "TrainOperationService"
+Module.Source = [[
+local TrainService = {}
+
+local TweenService = game:GetService("TweenService")
+local CollectionService = game:GetService("CollectionService")
+
+local TAG = "Train"
+
+function TrainService.StartOperations()
+	for _, train in CollectionService:GetTagged(TAG) do
+		if train:IsA("Model") then
+			TrainService.Operations(train)
+		else
+			warn(`[TrainService] Non-model was given train tag! {train:GetFullName()}`)
+		end
+	end
+end
+
+function TrainService.Operations(Train : Model)
+	if not Train then return end
+
+	local seat = Train:FindFirstChildOfClass("VehicleSeat")
+	if not seat then return end
+
+	local wheels = {}
+	for _, inst : Instance in ipairs(Train:GetDescendants()) do
+		if inst:IsA("HingeConstraint") and (inst.Name == "WheelL" or inst.Name == "WheelR") then
+			inst.ActuatorType = Enum.ActuatorType.Motor
+			inst.MotorMaxTorque = math.huge
+			table.insert(wheels, inst)
+		end
+	end
+
+	local tweens = {}
+	local maxSpeed = Train:GetAttribute("Speed")
+	local reverseSpeed = Train:GetAttribute("ReverseSpeed")
+	local targetVelocity = 0
+
+	seat:GetPropertyChangedSignal("Throttle"):Connect(function()
+		for _, wheel : HingeConstraint in ipairs(wheels) do
+			if wheel.Name == "WheelL" then
+				if seat.Throttle == 1 then
+					targetVelocity = maxSpeed
+				elseif seat.Throttle == -1 then
+					targetVelocity = -reverseSpeed
+				else
+					targetVelocity = 0
+				end
+			elseif wheel.Name == "WheelR" then
+				if seat.Throttle == 1 then
+					targetVelocity = -maxSpeed
+				elseif seat.Throttle == -1 then
+					targetVelocity = reverseSpeed
+				else
+					targetVelocity = 0
+				end	
+			end
+			if tweens[wheel] then
+				tweens[wheel]:Cancel()
+			end
+			local tween1 = TweenService:Create(wheel, TweenInfo.new(10, Enum.EasingStyle.Quad), {AngularVelocity = targetVelocity})
+			tween1:Play()
+			tweens[wheel] = tween1
+		end
+	end)
+end
+
+return TrainService
+
+-- PLACE INSIDE OF MAIN SCRIPT
+]]
+Module.Parent = Main

--- a/trainopservice.luau
+++ b/trainopservice.luau
@@ -1,11 +1,16 @@
 local TrainService = {}
 
 local TweenService = game:GetService("TweenService")
+local CollectionService = game:GetService("CollectionService")
+
+local TAG = "Train"
 
 function TrainService.StartOperations()
-	for _, train in ipairs(workspace:GetChildren()) do
-		if train:IsA("Model") and train:HasTag("Train") then
+	for _, train in CollectionService:GetTagged(TAG) do
+		if train:IsA("Model") then
 			TrainService.Operations(train)
+		else
+			warn(`[TrainService] Non-model was given train tag! {train:GetFullName()}`)
 		end
 	end
 end


### PR DESCRIPTION
- Add a quick setup
- Make trainopsservice use CollectionService::GetTagged instead of Instance::GetChildren, allowing for trains to be initialised even not if direct child of workspace